### PR TITLE
Se quita el logo de Inces

### DIFF
--- a/acercade.rst
+++ b/acercade.rst
@@ -14,15 +14,8 @@ conocimientos sobre Odoo.
   :align: center
   :alt: Comunidad de Desarrollo del ERP Nacional - Bachaco-VE
 
+
   Comunidad de Desarrollo del ERP Nacional - Bachaco-VE
-
-
-.. figure:: _static/logos/inces.jpg
-  :align: center
-  :alt: Instituto Nacional de Capacitación y Educación Socialista - INCES
-
-  Instituto Nacional de Capacitación y Educación Socialista - INCES
-
 
 .. figure:: _static/logos/odoo.png
   :align: center


### PR DESCRIPTION
Esta institución no estuvo involucrada en la traducción, aún cuando varios de nosotros trabajabamos allí no fue política de la institución.
