### PR TITLE
corrigiendo sentencia import en __init__.py

### DIFF
--- a/capitulos/modelos-estructura-datos-aplicacion.rst
+++ b/capitulos/modelos-estructura-datos-aplicacion.rst
@@ -90,7 +90,10 @@ existentes, podemos usar estos comandos en la terminal:
     $ cd todo_ui 
     $ touch __openerp__.py
     $ touch todo_model.py 
-    $ echo "from . Import todo_model" > __init__.py
+    #$ echo "from . Import todo_model" > __init__.py
+    # aquí No se si Daniels se le escapo pero la sentencia funcional queda:
+    $ echo "import todo_model" > __init__.py
+
 
 Luego, debemos editar el archivo manifiesto ``__openerp__.py`` con este
 contenido:


### PR DESCRIPTION
es segunda vez que veo está sentencia en el libro estuve buscando la primera pero no la encontre las importaciones en el archivo **init**.py , la e fixeado en el cap 5 
